### PR TITLE
fix sighash of coinbase transaction

### DIFF
--- a/lib/transaction/input/input.js
+++ b/lib/transaction/input/input.js
@@ -118,6 +118,10 @@ Input.prototype.setScript = function(script) {
     this._script = script;
     this._script._isInput = true;
     this._scriptBuffer = script.toBuffer();
+  } else if (script === null) {
+    this._script = Script.empty();
+    this._script._isInput = true;
+    this._scriptBuffer = this._script.toBuffer();
   } else if (JSUtil.isHexa(script)) {
     // hex string script
     this._scriptBuffer = new buffer.Buffer(script, 'hex');

--- a/test/transaction/sighash.js
+++ b/test/transaction/sighash.js
@@ -8,11 +8,24 @@ var bitcore = require('../../');
 var Script = bitcore.Script;
 var BN = bitcore.crypto.BN;
 var Transaction = bitcore.Transaction;
+var Signature = bitcore.crypto.Signature;
 var sighash = Transaction.sighash;
 
 var vectors_sighash = require('../data/sighash.json');
 
 describe('sighash', function() {
+  it('should be able to compute sighash for a coinbase tx', function () {
+    var txhex = '02000000010000000000000000000000000000000000000000000000000000000000000000ffffffff2e039b1e1304c0737c5b68747470733a2f2f6769746875622e636f6d2f62636578742f01000001c096020000000000ffffffff014a355009000000001976a91448b20e254c0677e760bab964aec16818d6b7134a88ac00000000';
+    var tx = new Transaction(txhex);
+    var sighash = Transaction.Sighash.sighash(
+      tx,
+      Signature.SIGHASH_ALL,
+      0,
+      Script.empty()
+    );
+    sighash.toString('hex').should.equal('6829f7d44dfd4654749b8027f44c9381527199f78ae9b0d58ffc03fdab3c82f1');
+  });
+
   it('Should require amount for sigHash ForkId=0', function() {
     var vector = ["3eb87070042d16f9469b0080a3c1fe8de0feae345200beef8b1e0d7c62501ae0df899dca1e03000000066a0065525365ffffffffd14a9a335e8babddd89b5d0b6a0f41dd6b18848050a0fc48ce32d892e11817fd030000000863acac00535200527ff62cf3ad30d9064e180eaed5e6303950121a8086b5266b55156e4f7612f2c7ebf223e0020000000100ffffffff6273ca3aceb55931160fa7a3064682b4790ee016b4a5c0c0d101fd449dff88ba01000000055351ac526aa3b8223d0421f25b0400000000026552f92db70500000000075253516a656a53c4a908010000000000b5192901000000000652525251516aa148ca38", "acab53", 3, -1325231124, "fbbc83ed610e416d94dcee2bb3bc35dfea8060b8052c59eabd7e998e3e978328"];
     var txbuf = new buffer.Buffer(vector[0], 'hex');


### PR DESCRIPTION
bitcore-lib-cash was not able to compute the sighash of a coinbase
transaction. This is understandable because wallets built on bitcore
would probably not normally need to compute the sighash of a coinbase
transaction, which is something only miners and full nodes need to do.
Nonetheless, there are reasons why someone might want to use bitcore to
compute the sighash of a coinbase transaction, such as computing the
normalized transaction id of all transactions on the blockchain.

Coinbase transactions have "null" inputs, which means the input has 0
for the txid and max int for the output number. The bitcore input
.script property returns javascript null in that case, however the input
setScript property expects a script. A simple way to resolve this is to
allow the setScript method to accept a null value and to interpret that
as an empty script.