### PR TITLE
Drop the use of Bignum in CashAddr encoding

### DIFF
--- a/lib/address.js
+++ b/lib/address.js
@@ -270,7 +270,6 @@ Address.createMultisig = function(publicKeys, threshold, network) {
   return Address.payingTo(Script.buildMultisigOut(publicKeys, threshold), network);
 };
 
-
 function decodeCashAddress(address) {
 
 
@@ -362,7 +361,7 @@ function decodeCashAddress(address) {
   return info;
 }
 
-
+Address._decodeCashAddress = decodeCashAddress
 
 /**
  * Internal function to transform a bitcoin cash address string

--- a/lib/address.js
+++ b/lib/address.js
@@ -292,7 +292,7 @@ function decodeCashAddress(address) {
     }
 
     var prefixData = prefixToArray(prefix).concat([0]);
-    return polymod(prefixData.concat(payload)).eqn(0);
+    return polymod(prefixData.concat(payload)) === 0;
   }
 
   $.checkArgument(hasSingleCase(address), 'Mixed case');
@@ -726,14 +726,13 @@ function getHashSize(versionByte) {
  * Returns an array representation of the given checksum to be encoded
  * within the address' payload.
  *
- * @param {BigInteger} checksum Computed checksum.
+ * @param {number} checksum Computed checksum.
  */
 function checksumToArray(checksum) {
   var result = [];
-  var N31 = new BN(31);
   for (var i = 0; i < 8; ++i) {
-    result.push(checksum.and(N31).toNumber());
-    checksum = checksum.shrn(5);
+    result.push(checksum & 31);
+    checksum /= 32;
   }
   return result.reverse();
 }
@@ -744,32 +743,43 @@ function checksumToArray(checksum) {
  *
  * @param {Array} data Array of 5-bit integers over which the checksum is to be computed.
  */
- var GENERATOR = _.map(
-  [0x98f2bc8e61, 0x79b76d99e2, 0xf33e5fb3c4, 0xae2eabe2a8, 0x1e4f43e470], function(x){
-    return new BN(x);
-  }
-);
+var GENERATOR1 = [0x98, 0x79, 0xf3, 0xae, 0x1e];
+var GENERATOR2 = [0xf2bc8e61, 0xb76d99e2, 0x3e5fb3c4, 0x2eabe2a8, 0x4f43e470];
 
 function polymod(data) {
-
-  var checksum = new BN(1);
-  var C = new BN(0x07ffffffff);
-
-  for (var j=0; j<data.length; j++) {
-    var value = data[j];
-    var topBits = checksum.shrn(35);
-
-    checksum = checksum.and(C);
-    checksum = checksum.shln(5).xor(new BN(value));
-
-    for (var i = 0; i < GENERATOR.length; ++i) {
-      var D = topBits.shrn(i).and(BN.One);
-      if (D.eqn(1)) {
-        checksum = checksum.xor(GENERATOR[i]);
+  // Treat c as 8 bits + 32 bits
+  var c0 = 0, c1 = 1, C = 0;
+  for (var j = 0; j < data.length; j++) {
+    // Set C to c shifted by 35
+    C = c0 >>> 3;
+    // 0x[07]ffffffff
+    c0 &= 0x07;
+    // Shift as a whole number
+    c0 <<= 5;
+    c0 |= c1 >>> 27;
+    // 0xffffffff >>> 5
+    c1 &= 0x07ffffff;
+    c1 <<= 5;
+    // xor the last 5 bits
+    c1 ^= data[j];
+    for (var i = 0; i < GENERATOR1.length; ++i) {
+      if (C & (1 << i)) {
+        c0 ^= GENERATOR1[i];
+        c1 ^= GENERATOR2[i];
       }
     }
   }
-  return checksum.xor(BN.One);
+  c1 ^= 1;
+  // Negative numbers -> large positive numbers
+  if (c1 < 0) {
+    c1 ^= 1 << 31;
+    c1 += (1 << 30) * 2;
+  }
+  // Unless bitwise operations are used,
+  // numbers are consisting of 52 bits, except
+  // the sign bit. The result is max 40 bits,
+  // so it fits perfectly in one number!
+  return c0 * (1 << 30) * 4 + c1;
 }
 
 module.exports = Address;

--- a/test/address.js
+++ b/test/address.js
@@ -14,6 +14,7 @@ var Networks = bitcore.Networks;
 
 var validbase58 = require('./data/bitcoind/base58_keys_valid.json');
 var invalidbase58 = require('./data/bitcoind/base58_keys_invalid.json');
+var validCashAddr = require('./data/cashaddr.json')
 
 describe('Address', function() {
 
@@ -675,4 +676,25 @@ describe('Address', function() {
       }).to.throw('Number of required signatures must be less than or equal to the number of public keys');
     });
   });
+
+  describe('cashaddr test vectors', function () {
+    it('should validate each test vector', function () {
+      // vectors from here:
+      // https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki
+      // the test vectors include a number of addresses with type "15" which is not explained in the spec,
+      // so those are skipped
+      for (var i in validCashAddr) {
+        var obj = validCashAddr[i]
+        var payloadSize = obj.payloadSize
+        var type = obj.type
+        var cashaddr = obj.cashaddr
+        var payload = obj.payload
+        if (type === 15) continue // unknown type - not described in spec
+        var info = Address._decodeCashAddress(cashaddr)
+        info.type.should.equal(type === 0 ? 'pubkeyhash': 'scripthash')
+        info.hashBuffer.toString('hex').should.equal(payload.toLowerCase())
+        info.hashBuffer.length.should.equal(payloadSize)
+      }
+    })
+  })
 });

--- a/test/data/cashaddr.json
+++ b/test/data/cashaddr.json
@@ -1,0 +1,194 @@
+[
+  {
+    "payloadSize": 20,
+    "type": 0,
+    "cashaddr": "bitcoincash:qr6m7j9njldwwzlg9v7v53unlr4jkmx6eylep8ekg2",
+    "payload": "F5BF48B397DAE70BE82B3CCA4793F8EB2B6CDAC9"
+  },
+  {
+    "payloadSize": 20,
+    "type": 1,
+    "cashaddr": "bchtest:pr6m7j9njldwwzlg9v7v53unlr4jkmx6eyvwc0uz5t",
+    "payload": "F5BF48B397DAE70BE82B3CCA4793F8EB2B6CDAC9"
+  },
+  {
+    "payloadSize": 20,
+    "type": 1,
+    "cashaddr": "pref:pr6m7j9njldwwzlg9v7v53unlr4jkmx6ey65nvtks5",
+    "payload": "F5BF48B397DAE70BE82B3CCA4793F8EB2B6CDAC9"
+  },
+  {
+    "payloadSize": 20,
+    "type": 15,
+    "cashaddr": "prefix:0r6m7j9njldwwzlg9v7v53unlr4jkmx6ey3qnjwsrf",
+    "payload": "F5BF48B397DAE70BE82B3CCA4793F8EB2B6CDAC9"
+  },
+  {
+    "payloadSize": 24,
+    "type": 0,
+    "cashaddr": "bitcoincash:q9adhakpwzztepkpwp5z0dq62m6u5v5xtyj7j3h2ws4mr9g0",
+    "payload": "7ADBF6C17084BC86C1706827B41A56F5CA32865925E946EA"
+  },
+  {
+    "payloadSize": 24,
+    "type": 1,
+    "cashaddr": "bchtest:p9adhakpwzztepkpwp5z0dq62m6u5v5xtyj7j3h2u94tsynr",
+    "payload": "7ADBF6C17084BC86C1706827B41A56F5CA32865925E946EA"
+  },
+  {
+    "payloadSize": 24,
+    "type": 1,
+    "cashaddr": "pref:p9adhakpwzztepkpwp5z0dq62m6u5v5xtyj7j3h2khlwwk5v",
+    "payload": "7ADBF6C17084BC86C1706827B41A56F5CA32865925E946EA"
+  },
+  {
+    "payloadSize": 24,
+    "type": 15,
+    "cashaddr": "prefix:09adhakpwzztepkpwp5z0dq62m6u5v5xtyj7j3h2p29kc2lp",
+    "payload": "7ADBF6C17084BC86C1706827B41A56F5CA32865925E946EA"
+  },
+  {
+    "payloadSize": 28,
+    "type": 0,
+    "cashaddr": "bitcoincash:qgagf7w02x4wnz3mkwnchut2vxphjzccwxgjvvjmlsxqwkcw59jxxuz",
+    "payload": "3A84F9CF51AAE98A3BB3A78BF16A6183790B18719126325BFC0C075B"
+  },
+  {
+    "payloadSize": 28,
+    "type": 1,
+    "cashaddr": "bchtest:pgagf7w02x4wnz3mkwnchut2vxphjzccwxgjvvjmlsxqwkcvs7md7wt",
+    "payload": "3A84F9CF51AAE98A3BB3A78BF16A6183790B18719126325BFC0C075B"
+  },
+  {
+    "payloadSize": 28,
+    "type": 1,
+    "cashaddr": "pref:pgagf7w02x4wnz3mkwnchut2vxphjzccwxgjvvjmlsxqwkcrsr6gzkn",
+    "payload": "3A84F9CF51AAE98A3BB3A78BF16A6183790B18719126325BFC0C075B"
+  },
+  {
+    "payloadSize": 28,
+    "type": 15,
+    "cashaddr": "prefix:0gagf7w02x4wnz3mkwnchut2vxphjzccwxgjvvjmlsxqwkc5djw8s9g",
+    "payload": "3A84F9CF51AAE98A3BB3A78BF16A6183790B18719126325BFC0C075B"
+  },
+  {
+    "payloadSize": 32,
+    "type": 0,
+    "cashaddr": "bitcoincash:qvch8mmxy0rtfrlarg7ucrxxfzds5pamg73h7370aa87d80gyhqxq5nlegake",
+    "payload": "3173EF6623C6B48FFD1A3DCC0CC6489B0A07BB47A37F47CFEF4FE69DE825C060"
+  },
+  {
+    "payloadSize": 32,
+    "type": 1,
+    "cashaddr": "bchtest:pvch8mmxy0rtfrlarg7ucrxxfzds5pamg73h7370aa87d80gyhqxq7fqng6m6",
+    "payload": "3173EF6623C6B48FFD1A3DCC0CC6489B0A07BB47A37F47CFEF4FE69DE825C060"
+  },
+  {
+    "payloadSize": 32,
+    "type": 1,
+    "cashaddr": "pref:pvch8mmxy0rtfrlarg7ucrxxfzds5pamg73h7370aa87d80gyhqxq4k9m7qf9",
+    "payload": "3173EF6623C6B48FFD1A3DCC0CC6489B0A07BB47A37F47CFEF4FE69DE825C060"
+  },
+  {
+    "payloadSize": 32,
+    "type": 15,
+    "cashaddr": "prefix:0vch8mmxy0rtfrlarg7ucrxxfzds5pamg73h7370aa87d80gyhqxqsh6jgp6w",
+    "payload": "3173EF6623C6B48FFD1A3DCC0CC6489B0A07BB47A37F47CFEF4FE69DE825C060"
+  },
+  {
+    "payloadSize": 40,
+    "type": 0,
+    "cashaddr": "bitcoincash:qnq8zwpj8cq05n7pytfmskuk9r4gzzel8qtsvwz79zdskftrzxtar994cgutavfklv39gr3uvz",
+    "payload": "C07138323E00FA4FC122D3B85B9628EA810B3F381706385E289B0B25631197D194B5C238BEB136FB"
+  },
+  {
+    "payloadSize": 40,
+    "type": 1,
+    "cashaddr": "bchtest:pnq8zwpj8cq05n7pytfmskuk9r4gzzel8qtsvwz79zdskftrzxtar994cgutavfklvmgm6ynej",
+    "payload": "C07138323E00FA4FC122D3B85B9628EA810B3F381706385E289B0B25631197D194B5C238BEB136FB"
+  },
+  {
+    "payloadSize": 40,
+    "type": 1,
+    "cashaddr": "pref:pnq8zwpj8cq05n7pytfmskuk9r4gzzel8qtsvwz79zdskftrzxtar994cgutavfklv0vx5z0w3",
+    "payload": "C07138323E00FA4FC122D3B85B9628EA810B3F381706385E289B0B25631197D194B5C238BEB136FB"
+  },
+  {
+    "payloadSize": 40,
+    "type": 15,
+    "cashaddr": "prefix:0nq8zwpj8cq05n7pytfmskuk9r4gzzel8qtsvwz79zdskftrzxtar994cgutavfklvwsvctzqy",
+    "payload": "C07138323E00FA4FC122D3B85B9628EA810B3F381706385E289B0B25631197D194B5C238BEB136FB"
+  },
+  {
+    "payloadSize": 48,
+    "type": 0,
+    "cashaddr": "bitcoincash:qh3krj5607v3qlqh5c3wq3lrw3wnuxw0sp8dv0zugrrt5a3kj6ucysfz8kxwv2k53krr7n933jfsunqex2w82sl",
+    "payload": "E361CA9A7F99107C17A622E047E3745D3E19CF804ED63C5C40C6BA763696B98241223D8CE62AD48D863F4CB18C930E4C"
+  },
+  {
+    "payloadSize": 48,
+    "type": 1,
+    "cashaddr": "bchtest:ph3krj5607v3qlqh5c3wq3lrw3wnuxw0sp8dv0zugrrt5a3kj6ucysfz8kxwv2k53krr7n933jfsunqnzf7mt6x",
+    "payload": "E361CA9A7F99107C17A622E047E3745D3E19CF804ED63C5C40C6BA763696B98241223D8CE62AD48D863F4CB18C930E4C"
+  },
+  {
+    "payloadSize": 48,
+    "type": 1,
+    "cashaddr": "pref:ph3krj5607v3qlqh5c3wq3lrw3wnuxw0sp8dv0zugrrt5a3kj6ucysfz8kxwv2k53krr7n933jfsunqjntdfcwg",
+    "payload": "E361CA9A7F99107C17A622E047E3745D3E19CF804ED63C5C40C6BA763696B98241223D8CE62AD48D863F4CB18C930E4C"
+  },
+  {
+    "payloadSize": 48,
+    "type": 15,
+    "cashaddr": "prefix:0h3krj5607v3qlqh5c3wq3lrw3wnuxw0sp8dv0zugrrt5a3kj6ucysfz8kxwv2k53krr7n933jfsunqakcssnmn",
+    "payload": "E361CA9A7F99107C17A622E047E3745D3E19CF804ED63C5C40C6BA763696B98241223D8CE62AD48D863F4CB18C930E4C"
+  },
+  {
+    "payloadSize": 56,
+    "type": 0,
+    "cashaddr": "bitcoincash:qmvl5lzvdm6km38lgga64ek5jhdl7e3aqd9895wu04fvhlnare5937w4ywkq57juxsrhvw8ym5d8qx7sz7zz0zvcypqscw8jd03f",
+    "payload": "D9FA7C4C6EF56DC4FF423BAAE6D495DBFF663D034A72D1DC7D52CBFE7D1E6858F9D523AC0A7A5C34077638E4DD1A701BD017842789982041"
+  },
+  {
+    "payloadSize": 56,
+    "type": 1,
+    "cashaddr": "bchtest:pmvl5lzvdm6km38lgga64ek5jhdl7e3aqd9895wu04fvhlnare5937w4ywkq57juxsrhvw8ym5d8qx7sz7zz0zvcypqs6kgdsg2g",
+    "payload": "D9FA7C4C6EF56DC4FF423BAAE6D495DBFF663D034A72D1DC7D52CBFE7D1E6858F9D523AC0A7A5C34077638E4DD1A701BD017842789982041"
+  },
+  {
+    "payloadSize": 56,
+    "type": 1,
+    "cashaddr": "pref:pmvl5lzvdm6km38lgga64ek5jhdl7e3aqd9895wu04fvhlnare5937w4ywkq57juxsrhvw8ym5d8qx7sz7zz0zvcypqsammyqffl",
+    "payload": "D9FA7C4C6EF56DC4FF423BAAE6D495DBFF663D034A72D1DC7D52CBFE7D1E6858F9D523AC0A7A5C34077638E4DD1A701BD017842789982041"
+  },
+  {
+    "payloadSize": 56,
+    "type": 15,
+    "cashaddr": "prefix:0mvl5lzvdm6km38lgga64ek5jhdl7e3aqd9895wu04fvhlnare5937w4ywkq57juxsrhvw8ym5d8qx7sz7zz0zvcypqsgjrqpnw8",
+    "payload": "D9FA7C4C6EF56DC4FF423BAAE6D495DBFF663D034A72D1DC7D52CBFE7D1E6858F9D523AC0A7A5C34077638E4DD1A701BD017842789982041"
+  },
+  {
+    "payloadSize": 64,
+    "type": 0,
+    "cashaddr": "bitcoincash:qlg0x333p4238k0qrc5ej7rzfw5g8e4a4r6vvzyrcy8j3s5k0en7calvclhw46hudk5flttj6ydvjc0pv3nchp52amk97tqa5zygg96mtky5sv5w",
+    "payload": "D0F346310D5513D9E01E299978624BA883E6BDA8F4C60883C10F28C2967E67EC77ECC7EEEAEAFC6DA89FAD72D11AC961E164678B868AEEEC5F2C1DA08884175B"
+  },
+  {
+    "payloadSize": 64,
+    "type": 1,
+    "cashaddr": "bchtest:plg0x333p4238k0qrc5ej7rzfw5g8e4a4r6vvzyrcy8j3s5k0en7calvclhw46hudk5flttj6ydvjc0pv3nchp52amk97tqa5zygg96mc773cwez",
+    "payload": "D0F346310D5513D9E01E299978624BA883E6BDA8F4C60883C10F28C2967E67EC77ECC7EEEAEAFC6DA89FAD72D11AC961E164678B868AEEEC5F2C1DA08884175B"
+  },
+  {
+    "payloadSize": 64,
+    "type": 1,
+    "cashaddr": "pref:plg0x333p4238k0qrc5ej7rzfw5g8e4a4r6vvzyrcy8j3s5k0en7calvclhw46hudk5flttj6ydvjc0pv3nchp52amk97tqa5zygg96mg7pj3lh8",
+    "payload": "D0F346310D5513D9E01E299978624BA883E6BDA8F4C60883C10F28C2967E67EC77ECC7EEEAEAFC6DA89FAD72D11AC961E164678B868AEEEC5F2C1DA08884175B"
+  },
+  {
+    "payloadSize": 64,
+    "type": 15,
+    "cashaddr": "prefix:0lg0x333p4238k0qrc5ej7rzfw5g8e4a4r6vvzyrcy8j3s5k0en7calvclhw46hudk5flttj6ydvjc0pv3nchp52amk97tqa5zygg96ms92w6845",
+    "payload": "D0F346310D5513D9E01E299978624BA883E6BDA8F4C60883C10F28C2967E67EC77ECC7EEEAEAFC6DA89FAD72D11AC961E164678B868AEEEC5F2C1DA08884175B"
+  }
+]


### PR DESCRIPTION
It improves the PolyMod generation while making it even more readable. I aimed the polymod function to strictly return a number; if you didn't like that part, let me know, and it'll simply return an array.