### PR TITLE
Not able to Calculate SighashForkid of long script.

### DIFF
--- a/lib/transaction/sighash.js
+++ b/lib/transaction/sighash.js
@@ -119,7 +119,7 @@ function getHash (w) {
   writer.writeUInt32LE(input.outputIndex);
 
   // scriptCode of the input (serialized as scripts inside CTxOuts)
-  writer.writeUInt8(subscript.toBuffer().length)
+  writer.writeVarintNum(subscript.toBuffer().length)
   writer.write(subscript.toBuffer());
 
   // value of the output spent by this input (8-byte little endian)


### PR DESCRIPTION
The SegWit version doesn't have this bug.

https://github.com/bitpay/bitcore-lib/blob/86583608814dfc513e675d7b853806caf9bd95e7/lib/transaction/transaction.js#L1206-L1209

@matiu 