### PR TITLE
move phantomjs-prebuilt to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,14 +39,14 @@
     "buffer-compare": "=1.1.1",
     "elliptic": "=6.4.0",
     "inherits": "=2.0.1",
-    "lodash": "=4.17.4",
-    "phantomjs-prebuilt": "^2.1.16"
+    "lodash": "=4.17.4"
   },
   "devDependencies": {
     "bitcore-build": "https://github.com/bitpay/bitcore-build.git#d4e8b2b2f1e2c065c3a807dcb6a6250f61d67ab3",
     "brfs": "^1.2.0",
     "chai": "^1.10.0",
     "gulp": "^3.8.10",
+    "phantomjs-prebuilt": "^2.1.16",
     "sinon": "^1.13.0"
   },
   "license": "MIT"


### PR DESCRIPTION
Fixes: https://github.com/bitpay/bitcore-lib-cash/issues/11