### PR TITLE
update lodash to version 4.17.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "buffer-compare": "=1.1.1",
     "elliptic": "=6.4.0",
     "inherits": "=2.0.1",
-    "lodash": "=4.17.4"
+    "lodash": "=4.17.11"
   },
   "devDependencies": {
     "bitcore-build": "https://github.com/bitpay/bitcore-build.git#d4e8b2b2f1e2c065c3a807dcb6a6250f61d67ab3",


### PR DESCRIPTION
This updates lodash to version 4.17.11 to fix https://www.npmjs.com/advisories/577.