### PR TITLE
fix op return

### DIFF
--- a/lib/script/script.js
+++ b/lib/script/script.js
@@ -165,15 +165,6 @@ Script.fromASM = function(str) {
         opcodenum: opcodenum
       });
       i = i + 1;
-    } else if (opcodenum === Opcode.OP_PUSHDATA1 ||
-      opcodenum === Opcode.OP_PUSHDATA2 ||
-      opcodenum === Opcode.OP_PUSHDATA4) {
-      script.chunks.push({
-        buf: Buffer.from(tokens[i + 2], 'hex'),
-        len: parseInt(tokens[i + 1]),
-        opcodenum: opcodenum
-      });
-      i = i + 3;
     } else {
       script.chunks.push({
         opcodenum: opcodenum

--- a/lib/script/script.js
+++ b/lib/script/script.js
@@ -480,7 +480,7 @@ Script.prototype.isDataOut = function() {
     this.toBuffer().length <= 223; // 223 instead of 220 because (+1 for OP_RETURN, +2 for the pushdata opcodes)
   if (!step1) return false;
   var chunks = this.chunks.slice(1);
-  var script2 = new Script({chunks});
+  var script2 = new Script({chunks: chunks});
   return script2.isPushOnly();
 };
 

--- a/lib/script/script.js
+++ b/lib/script/script.js
@@ -146,10 +146,23 @@ Script.fromASM = function(str) {
 
     if (_.isUndefined(opcodenum)) {
       var buf = Buffer.from(tokens[i], 'hex');
+      var opcodenum;
+      var len = buf.length
+      if (len >= 0 && len < Opcode.OP_PUSHDATA1) {
+        opcodenum = len;
+      } else if (len < Math.pow(2, 8)) {
+        opcodenum = Opcode.OP_PUSHDATA1;
+      } else if (len < Math.pow(2, 16)) {
+        opcodenum = Opcode.OP_PUSHDATA2;
+      } else if (len < Math.pow(2, 32)) {
+        opcodenum = Opcode.OP_PUSHDATA4;
+      } else {
+        throw new Error('You can\'t push that much data');
+      }
       script.chunks.push({
         buf: buf,
         len: buf.length,
-        opcodenum: buf.length
+        opcodenum: opcodenum
       });
       i = i + 1;
     } else if (opcodenum === Opcode.OP_PUSHDATA1 ||
@@ -462,13 +475,13 @@ Script.prototype.isMultisigIn = function() {
  * @returns {boolean} true if this is a valid standard OP_RETURN output
  */
 Script.prototype.isDataOut = function() {
-  return this.chunks.length >= 1 &&
+  var step1 = this.chunks.length >= 1 &&
     this.chunks[0].opcodenum === Opcode.OP_RETURN &&
-    (this.chunks.length === 1 ||
-      (this.chunks.length === 2 &&
-        this.chunks[1].buf &&
-        this.chunks[1].buf.length <= Script.OP_RETURN_STANDARD_SIZE &&
-        this.chunks[1].length === this.chunks.len));
+    this.toBuffer().length <= 223 // 223 instead of 220 because (+1 for OP_RETURN, +2 for the pushdata opcodes)
+  if (!step1) return false
+  var chunks = this.chunks.slice(1)
+  var script2 = new Script({chunks})
+  return script2.isPushOnly()
 };
 
 /**
@@ -497,7 +510,10 @@ Script.prototype.getData = function() {
  */
 Script.prototype.isPushOnly = function() {
   return _.every(this.chunks, function(chunk) {
-    return chunk.opcodenum <= Opcode.OP_16;
+    return chunk.opcodenum <= Opcode.OP_16 ||
+      chunk.opcodenum === Opcode.OP_PUSHDATA1 ||
+      chunk.opcodenum === Opcode.OP_PUSHDATA2 ||
+      chunk.opcodenum === Opcode.OP_PUSHDATA4;
   });
 };
 

--- a/lib/script/script.js
+++ b/lib/script/script.js
@@ -271,9 +271,9 @@ Script.prototype._chunkToString = function(chunk, type) {
     }
   } else {
     // data chunk
-    if (!asm && opcodenum === Opcode.OP_PUSHDATA1 ||
+    if (!asm && (opcodenum === Opcode.OP_PUSHDATA1 ||
       opcodenum === Opcode.OP_PUSHDATA2 ||
-      opcodenum === Opcode.OP_PUSHDATA4) {
+      opcodenum === Opcode.OP_PUSHDATA4)) {
       str = str + ' ' + Opcode(opcodenum).toString();
     }
     if (chunk.len > 0) {

--- a/lib/script/script.js
+++ b/lib/script/script.js
@@ -147,7 +147,7 @@ Script.fromASM = function(str) {
     if (_.isUndefined(opcodenum)) {
       var buf = Buffer.from(tokens[i], 'hex');
       var opcodenum;
-      var len = buf.length
+      var len = buf.length;
       if (len >= 0 && len < Opcode.OP_PUSHDATA1) {
         opcodenum = len;
       } else if (len < Math.pow(2, 8)) {
@@ -477,11 +477,11 @@ Script.prototype.isMultisigIn = function() {
 Script.prototype.isDataOut = function() {
   var step1 = this.chunks.length >= 1 &&
     this.chunks[0].opcodenum === Opcode.OP_RETURN &&
-    this.toBuffer().length <= 223 // 223 instead of 220 because (+1 for OP_RETURN, +2 for the pushdata opcodes)
-  if (!step1) return false
-  var chunks = this.chunks.slice(1)
-  var script2 = new Script({chunks})
-  return script2.isPushOnly()
+    this.toBuffer().length <= 223; // 223 instead of 220 because (+1 for OP_RETURN, +2 for the pushdata opcodes)
+  if (!step1) return false;
+  var chunks = this.chunks.slice(1);
+  var script2 = new Script({chunks});
+  return script2.isPushOnly();
 };
 
 /**

--- a/lib/script/script.js
+++ b/lib/script/script.js
@@ -156,8 +156,6 @@ Script.fromASM = function(str) {
         opcodenum = Opcode.OP_PUSHDATA2;
       } else if (len < Math.pow(2, 32)) {
         opcodenum = Opcode.OP_PUSHDATA4;
-      } else {
-        throw new Error('You can\'t push that much data');
       }
       script.chunks.push({
         buf: buf,

--- a/test/script/script.js
+++ b/test/script/script.js
@@ -489,6 +489,8 @@ describe('Script', function() {
       Script('OP_0').isPushOnly().should.equal(true);
       Script('OP_0 OP_RETURN').isPushOnly().should.equal(false);
       Script('OP_PUSHDATA1 5 0x1010101010').isPushOnly().should.equal(true);
+      Script('OP_PUSHDATA2 5 0x1010101010').isPushOnly().should.equal(true);
+      Script('OP_PUSHDATA4 5 0x1010101010').isPushOnly().should.equal(true);
       // like bitcoind, we regard OP_RESERVED as being "push only"
       Script('OP_RESERVED').isPushOnly().should.equal(true);
     });

--- a/test/script/script.js
+++ b/test/script/script.js
@@ -198,6 +198,19 @@ describe('Script', function() {
       script.chunks[3].opcodenum.should.equal(Opcode.OP_EQUALVERIFY);
       script.chunks[4].opcodenum.should.equal(Opcode.OP_CHECKSIG);
     });
+
+    it('should parse this known problematic script in ASM', function () {
+      var asm = 'OP_RETURN 026d02 0568656c6c6f';
+      var script = Script.fromASM(asm);
+      script.toASM().should.equal(asm);
+    });
+
+    it('should parse this long script in ASM', function () {
+      var asm = 'OP_RETURN 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000';
+      var script = Script.fromASM(asm);
+      script.chunks[1].opcodenum.should.equal(Opcode.OP_PUSHDATA1)
+      script.toASM().should.equal(asm);
+    });
   });
 
   describe('#fromString', function() {
@@ -265,11 +278,16 @@ describe('Script', function() {
       Script('OP_RETURN').isDataOut().should.equal(true);
     });
 
+    it('validates that this two part OP_RETURN is standard', function() {
+      Script.fromASM('OP_RETURN 026d02 0568656c6c6f').isDataOut().should.equal(true);
+    });
+
     it('validates that this 40-byte OP_RETURN is standard', function() {
       var buf = new Buffer(40);
       buf.fill(0);
       Script('OP_RETURN 40 0x' + buf.toString('hex')).isDataOut().should.equal(true);
     });
+
     it('validates that this 80-byte OP_RETURN is standard', function() {
       var buf = new Buffer(80);
       buf.fill(0);

--- a/test/script/script.js
+++ b/test/script/script.js
@@ -205,10 +205,27 @@ describe('Script', function() {
       script.toASM().should.equal(asm);
     });
 
-    it('should parse this long script in ASM', function () {
-      var asm = 'OP_RETURN 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000';
+    it('should parse this long PUSHDATA1 script in ASM', function () {
+      var buf = Buffer.alloc(220, 0);
+      var asm = 'OP_RETURN ' + buf.toString('hex');
       var script = Script.fromASM(asm);
       script.chunks[1].opcodenum.should.equal(Opcode.OP_PUSHDATA1)
+      script.toASM().should.equal(asm);
+    });
+
+    it('should parse this long PUSHDATA2 script in ASM', function () {
+      var buf = Buffer.alloc(1024, 0);
+      var asm = 'OP_RETURN ' + buf.toString('hex');
+      var script = Script.fromASM(asm);
+      script.chunks[1].opcodenum.should.equal(Opcode.OP_PUSHDATA2)
+      script.toASM().should.equal(asm);
+    });
+
+    it('should parse this long PUSHDATA4 script in ASM', function () {
+      var buf = Buffer.alloc(Math.pow(2, 17), 0);
+      var asm = 'OP_RETURN ' + buf.toString('hex');
+      var script = Script.fromASM(asm);
+      script.chunks[1].opcodenum.should.equal(Opcode.OP_PUSHDATA4)
       script.toASM().should.equal(asm);
     });
   });


### PR DESCRIPTION
We were unable to pass multiple chunks of data in an OP_RETURN. This is
now considered standard in Bitcoin Cash which is not the same as Bitcoin
Core. Now we can. The problem was twofold. First, we needed to fix the
fromASM method to actually use the larger PUSHDATA opcodes correctly so
that the isDataOut method would work properly. Secondly, we needed to
fix the isPushOnly method to support the larger PUSHDATA opcodes.